### PR TITLE
Add link to standard Swedish stopwords on github

### DIFF
--- a/stoppord/README.md
+++ b/stoppord/README.md
@@ -4,3 +4,5 @@
 - 285 svenska politiska stoppord ([CSV](stoppord-politik.csv)). Framför allt baserad på stoppordlistan ovan.
 
 Källa: [Nico Lehmann](https://github.com/ekorn/Keywords/tree/master/stopwords), kompletterad av Peter Dahlgren
+
+Se även: [stopwords-iso för svenska](https://github.com/stopwords-iso/stopwords-sv/blob/master/stopwords-sv.txt)


### PR DESCRIPTION
When looking for standard Swedish stopwords lists I've come across and used this. Maybe it's safest just to add a link to it instead of copying the file in case of updates.